### PR TITLE
Use sentence case for strings

### DIFF
--- a/filemojicompat-ui/src/main/res/values/strings.xml
+++ b/filemojicompat-ui/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="download_verb">Download</string>
-    <string name="system_default_pack">System Default</string>
+    <string name="system_default_pack">System default</string>
     <string name="system_default_pack_description">The default emojis of your device</string>
     <string name="import_pack">Import emoji pack</string>
     <string name="import_pack_description">Use a different emoji pack</string>
@@ -19,6 +19,6 @@
     <string name="undo">Undo</string>
     <string name="emoji_icon_content_description">Emoji pack icon</string>
     <string name="select_pack">Select emoji pack</string>
-    <string name="emoji_style">Emoji Style</string>
+    <string name="emoji_style">Emoji style</string>
     <string name="pack_already_imported">Pack is already imported</string>
 </resources>


### PR DESCRIPTION
Android uses sentence case, not title case for strings in menus, lists, etc.

See https://github.com/tuskyapp/Tusky/pull/3289