### PR TITLE
remove unused dependencies

### DIFF
--- a/filemojicompat-autoinit/build.gradle
+++ b/filemojicompat-autoinit/build.gradle
@@ -35,8 +35,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.startup:startup-runtime:1.1.1'
     api project(path: ':filemojicompat-defaults')
     api project(path: ':filemojicompat-ui')

--- a/filemojicompat-defaults/build.gradle
+++ b/filemojicompat-defaults/build.gradle
@@ -35,6 +35,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.appcompat:appcompat:1.5.0'
     api project(path: ':filemojicompat-ui')
 }

--- a/filemojicompat-ui/build.gradle
+++ b/filemojicompat-ui/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.preference:preference-ktx:1.2.0'
+    implementation 'androidx.activity:activity-ktx:1.5.1'
+    implementation 'androidx.lifecycle:lifecycle-common-java8:2.5.1'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.emoji2:emoji2:1.2.0'

--- a/filemojicompat-ui/build.gradle
+++ b/filemojicompat-ui/build.gradle
@@ -32,13 +32,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.preference:preference-ktx:1.2.0'
-    implementation 'androidx.activity:activity-ktx:1.5.1'
-    implementation 'androidx.lifecycle:lifecycle-common-java8:2.5.1'
-    implementation 'androidx.preference:preference-ktx:1.2.0'
-    implementation "androidx.multidex:multidex:2.0.1"
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'com.google.android.material:material:1.6.1'
-    implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'androidx.emoji2:emoji2:1.2.0'
     api project(path: ':filemojicompat')
 }

--- a/filemojicompat/build.gradle
+++ b/filemojicompat/build.gradle
@@ -29,7 +29,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.emoji2:emoji2:1.2.0'
 }
 


### PR DESCRIPTION
This is important because the dependencies also get pulled into the projects of library consumers and they might not want or need these